### PR TITLE
Enable specific team retrieval and editing

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,17 +1,45 @@
 class TeamsController < ApplicationController
 
+  def index
+    render json: Team.all, status: :ok
+  end
+
+  def show
+    show_team = Team.find_by(id: params[:team_id])
+
+    if show_team
+      render json: show_team, status: :ok
+
+    else
+      render json: {
+          errors: 'The team does not exist'
+      }, status: :bad_request
+    end
+  end
+
   def create
     @create_team = Team.new(team_params)
 
     if @create_team.save
       render json: @create_team, status: :created
+
     else
       render json: @create_team.errors, status: :unprocessable_entity
     end
   end
 
-  def show
-    render json: Team.all, status: :ok
+  def update
+    edit_team = Team.find_by(id: params[:team_id])
+
+    if edit_team
+      edit_team.update_attributes(team_params)
+      render json: edit_team, status: :ok
+
+    else
+      render json: {
+          errors: 'The team does not exist'
+      }, status: :bad_request
+    end
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   scope "teams" do
-    get "/" => "teams#show"
+    get "/" => "teams#index"
+    get "/show/:team_id" => "teams#show"
     post "/create" => "teams#create"
+    put "/edit/:team_id" => "teams#update"
   end
 end

--- a/spec/requests/teams_spec.rb
+++ b/spec/requests/teams_spec.rb
@@ -4,15 +4,16 @@ require './spec/support/request_helper'
 RSpec.describe Team, type: :request do
   include RequestSpecHelper
   let(:team_params) {
-      {
+   {
         name: 'Kabonge',
         description: 'where pride meets passion',
         location: 'Kirinyaga',
         nickname: '11 Bullets'
-      }
+   }
    }
 
   let!(:teams) { create_list(:team, 10) }
+  let(:team_id) { teams.first.id }
 
   describe 'POST teams/create' do
 
@@ -64,5 +65,57 @@ RSpec.describe Team, type: :request do
       end
     end
   end
-end
 
+  describe 'GET /teams/show/:id' do
+
+    context 'when the request is valid' do
+      before { get "/teams/show/#{team_id}" }
+
+      it 'returns a hash with 7 keys' do
+        expect(json.size).to eq 7
+      end
+
+      it 'returns status code 200' do
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'when the request is invalid' do
+      let(:team_id) { 100 }
+      before { get "/teams/show/#{team_id}" }
+
+      it 'returns an error message and status code 400' do
+        expect(response).to have_http_status(400)
+        expect(json['errors']).to eq("The team does not exist")
+      end
+    end
+  end
+
+  describe 'PUT /teams/edit/:id' do
+
+    context 'when the request is valid' do
+      before { put "/teams/edit/#{team_id}" }
+
+      it 'returns a hash with 7 keys' do
+        expect(json.size).to eq 7
+      end
+
+      it 'returns status code 200' do
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'when the request is invalid' do
+      let(:team_id) { 100 }
+      before { put "/teams/edit/#{team_id}" }
+
+      it 'returns an error message' do
+        expect(json['errors']).to eq("The team does not exist")
+      end
+
+      it 'returns status code 400' do
+        expect(response).to have_http_status(400)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What does this PR do?
- Enables the user to retrieve specific team and edit.

#### Description of Task to be completed?
- Create an update controller.
- Create a single team retrieval controller.
- Test update team.
- Test specific team retrieval.

#### How should this be manually tested?
- Open `postman`.
- To show specific team use `GET` method and type `http://127.0.0.1:3000/teams/show/:id`
- To edit specific team use `PUT` method and type `http://127.0.0.1:3000/teams/edit/:id`

#### Any background context you want to add?
- N/A
#### Screenshots
- N/A