### PR TITLE
Allow the user to delete a team

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -42,6 +42,18 @@ class TeamsController < ApplicationController
     end
   end
 
+  def destroy
+    delete_team = Team.find_by(id: params[:team_id])
+
+    if delete_team
+      delete_team.destroy
+      render json: { message: "Team was successfully deleted" }, status: :ok
+
+    else
+      render json: { errors: "The team does not exist" }, status: :bad_request
+    end
+  end
+
   private
 
   def team_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,6 @@ Rails.application.routes.draw do
     get "/show/:team_id" => "teams#show"
     post "/create" => "teams#create"
     put "/edit/:team_id" => "teams#update"
+    delete "/delete/:team_id" => "teams#destroy"
   end
 end

--- a/spec/requests/teams_spec.rb
+++ b/spec/requests/teams_spec.rb
@@ -66,6 +66,28 @@ RSpec.describe Team, type: :request do
     end
   end
 
+  describe "DELETE /team/delete/:team_id" do
+
+    context "when the request is valid" do
+      before { delete "/teams/delete/#{team_id}" }
+
+      it "returns a success message and status code 200" do
+        expect(json["message"]).to eq("Team was successfully deleted")
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when the request is invalid" do
+      let(:team_id) { 100 }
+      before { delete "/teams/delete/#{team_id}" }
+
+      it "returns an error message and status code 400" do
+        expect(json["errors"]).to eq("The team does not exist")
+        expect(response).to have_http_status(400)
+      end
+    end
+  end
+
   describe 'GET /teams/show/:id' do
 
     context 'when the request is valid' do


### PR DESCRIPTION
#### What does this PR do?
- Allows the user to delete a specific team.

#### Description of Task to be completed?
- Create a controller for deleting the team.
- Connect the request to the controller via the route.
- Add tests.

#### How should this be manually tested?
- Open `Postman`.
- Use the `DELETE` method and type `http://127.0.0.1:3000/teams/delete/:team_id` and hit send.

#### Any background context you want to add?
- N/A

#### Screenshots
- N/A