### PR TITLE
#160750678 Enable league CRUD operations by Admin

### DIFF
--- a/app/controllers/leagues_controller.rb
+++ b/app/controllers/leagues_controller.rb
@@ -1,0 +1,78 @@
+class LeaguesController < ApplicationController
+  before_action :authenticate_current_user, except: [:index, :show]
+  before_action :set_league, only: %i(update destroy)
+  after_action :verify_authorized, except: [:index, :show]
+
+  def index
+    leagues = League.all
+
+    if leagues.empty?
+      render json: { "error": "No leagues!" },
+             status: :bad_request
+
+    else
+      render json: leagues, status: :ok
+    end
+  end
+
+  def show
+    league = League.find_by(id: params[:league_id])
+
+    if league.blank?
+      render json: { "error": "The league does not exist" },
+             status: :bad_request
+
+    else
+      render json: league, status: :ok
+    end
+  end
+
+  def create
+    league = League.new(league_params)
+    authorize league
+
+    if league.save
+      render json: league, status: :created
+
+    else
+      render json: league.errors, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @league
+      @league.update_attributes(league_params)
+      render json: @league, status: :ok
+
+    else
+      render json: { errors: "The league does not exist" },
+             status: :bad_request
+    end
+  end
+
+  def destroy
+    if @league
+      @league.destroy
+      render json: { message: "League was successfully deleted" },
+             status: :ok
+
+    else
+      render json: { errors: "The league does not exist" },
+             status: :bad_request
+    end
+  end
+
+  private
+
+  def set_league
+    @league = League.find_by(id: params[:league_id])
+    authorize @league
+  end
+
+  def league_params
+    params.permit(
+        :title,
+        :season
+    )
+  end
+end

--- a/app/policies/league_policy.rb
+++ b/app/policies/league_policy.rb
@@ -1,0 +1,13 @@
+class LeaguePolicy < ApplicationPolicy
+  def create?
+    user.present? && user.admin?
+  end
+
+  def update?
+    user.present? && user.admin?
+  end
+
+  def destroy?
+    user.present? && user.admin?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,4 +35,12 @@ Rails.application.routes.draw do
     put "/:fixture_id" => "fixtures#update"
     delete "/:fixture_id" => "fixtures#destroy"
   end
+
+  scope "leagues" do
+    get "/" => "leagues#index"
+    post "/" => "leagues#create"
+    get "/:league_id" => "leagues#show"
+    put "/:league_id" => "leagues#update"
+    delete "/:league_id" => "leagues#destroy"
+  end
 end

--- a/db/migrate/20180924114158_create_leagues.rb
+++ b/db/migrate/20180924114158_create_leagues.rb
@@ -3,8 +3,6 @@ class CreateLeagues < ActiveRecord::Migration[5.2]
     create_table :leagues do |t|
       t.text :title
       t.text :season
-      t.integer :leagues_teams_id
-      t.integer :sponsor_id
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -142,6 +142,7 @@ ActiveRecord::Schema.define(version: 2018_10_03_151200) do
   add_foreign_key "events", "teams", column: "teams_id"
   add_foreign_key "fixtures", "teams", column: "away_team"
   add_foreign_key "fixtures", "teams", column: "home_team"
+  add_foreign_key "league_fixtures", "fixtures", column: "match_id"
   add_foreign_key "leagues_sponsors", "sponsors"
   add_foreign_key "leagues_teams", "teams"
   add_foreign_key "players", "teams"

--- a/spec/factories/leagues.rb
+++ b/spec/factories/leagues.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+
+  factory :league, class: League do
+    title { Faker::Football.competition }
+  end
+end

--- a/spec/requests/leagues_spec.rb
+++ b/spec/requests/leagues_spec.rb
@@ -1,0 +1,135 @@
+require "rails_helper"
+require "./spec/support/request_helper"
+RSpec.describe League, type: :request do
+
+  include RequestSpecHelper
+  include AuthenticationSpecHelper
+
+  let!(:role) { create(:role, name: "Admin") }
+
+  let!(:user) { create(:user, role_id: role.id) }
+
+  let!(:league) { create(:league) }
+
+  let(:league_id) { league.id }
+
+  let(:league_params) { attributes_for(:league) }
+
+  describe "POST /leagues" do
+    context "when the request is valid" do
+
+      before do
+        post "/leagues",
+             headers: authenticated_header(user),
+             params: league_params
+      end
+
+      it "creates a new league" do
+        expect(json.size).to eq 5
+      end
+
+      it "returns status code 201" do
+        expect(response).to have_http_status(201)
+      end
+    end
+  end
+
+  describe "GET /leagues" do
+    context "when the request is valid" do
+      before { get "/leagues" }
+
+      it "returns a list with 1 hash of a league" do
+        expect(json.size).to eq 1
+      end
+
+      it "returns status code 200" do
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when the request is invalid" do
+      let!(:league_id) { 1 }
+      before { get "/leagues/#{league_id}" }
+
+      it "returns an error message" do
+        expect(json["error"]).to eq("The league does not exist")
+      end
+
+      it "returns status code 400" do
+        expect(response).to have_http_status(400)
+      end
+    end
+  end
+
+  describe "DELETE leagues/:league_id" do
+    context "when the request is valid" do
+
+      before do
+        delete "/leagues/#{league_id}",
+               headers: authenticated_header(user)
+      end
+
+      it "returns a success message" do
+        expect(json["message"]).to eq("League was successfully deleted")
+      end
+
+      it "returns status code 200" do
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when the request is invalid" do
+
+      let(:league_id) { 0 }
+
+      before do
+        delete "/leagues/#{league_id}",
+               headers: authenticated_header(user)
+      end
+
+      it "returns an error message" do
+        expect(json["errors"]).to eq("The league does not exist")
+      end
+
+      it "returns status code 400" do
+        expect(response).to have_http_status(400)
+      end
+    end
+  end
+
+  describe "PUT /leagues/:league_id" do
+    context "when the request is valid" do
+
+      before do
+        put "/leagues/#{league_id}",
+            headers: authenticated_header(user)
+      end
+
+      it "returns a hash with 5 keys" do
+        expect(json.size).to eq 5
+      end
+
+      it "returns status code 200" do
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when the request is invalid" do
+
+      let(:league_id) { 0 }
+
+      before do
+        put "/leagues/#{league_id}",
+            headers: authenticated_header(user)
+      end
+
+      it "returns an error message" do
+        expect(json["errors"]).to eq("The league does not exist")
+      end
+
+      it "returns status code 400" do
+        expect(response).to have_http_status(400)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What does this PR do?
- Enable league CRUD operations by Admin.

#### Description of Task to be completed?
- Write tests for league CRUD operations
- Implement controller CRUD operations.
- Implement a policy such that only the admin can add, update or delete league.

#### PT story.
- [#160750678](https://www.pivotaltracker.com/story/show/160750678)