### PR TITLE
#160750695 Enable CRUD operations on the sponsors

### DIFF
--- a/app/controllers/sponsor_controller.rb
+++ b/app/controllers/sponsor_controller.rb
@@ -1,0 +1,77 @@
+class SponsorController < ApplicationController
+  before_action :authenticate_current_user, except: %i(index show)
+  before_action :set_sponsor, only: %i(update destroy)
+  after_action :verify_authorized, except: %i(index show)
+
+  def index
+    sponsors = Sponsor.all
+
+    if sponsors.empty?
+      render json: { errors: "No sponsors found!" },
+             status: :bad_request
+
+    else
+      render json: sponsors, status: :ok
+    end
+  end
+
+  def show
+    sponsor = Sponsor.find_by_id(params[:sponsor_id])
+
+    if sponsor
+      render json: sponsor, status: :ok
+
+    else
+      render json: { errors: "The sponsor does not exist" },
+             status: :bad_request
+    end
+  end
+
+  def create
+    sponsor = Sponsor.new(sponsor_params)
+    authorize sponsor
+
+    if sponsor.save
+      render json: sponsor, status: :created
+
+    else
+      render json: sponsor.errors, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @sponsor
+      @sponsor.update_attributes(sponsor_params)
+      render json: @sponsor, status: :ok
+
+    else
+      render json: { errors: "The sponsor does not exist" },
+             status: :bad_request
+    end
+  end
+
+  def destroy
+    if @sponsor
+      @sponsor.destroy
+      render json: { message: "Sponsor was successfully deleted" }, status: :ok
+
+    else
+      render json: { errors: "The sponsor does not exist" }, status: :bad_request
+    end
+  end
+
+  private
+
+  def set_sponsor
+    @sponsor = Sponsor.find_by(id: params[:sponsor_id])
+    authorize @sponsor
+  end
+
+  def sponsor_params
+    params.permit(
+      :name,
+      :description,
+      :contacts
+    )
+  end
+end

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -1,2 +1,5 @@
 class Sponsor < ApplicationRecord
+  validates_presence_of :name,
+                        :description,
+                        :contacts
 end

--- a/app/policies/sponsor_policy.rb
+++ b/app/policies/sponsor_policy.rb
@@ -1,0 +1,13 @@
+class SponsorPolicy < ApplicationPolicy
+  def create?
+    user.present? && user.admin?
+  end
+
+  def update?
+    user.present? && (user.admin? || user.sponsor?)
+  end
+
+  def destroy?
+    user.present? && user.admin?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,4 +51,12 @@ Rails.application.routes.draw do
     put "/:transfer_id" => "transfer#update"
     delete "/:transfer_id" => "transfer#destroy"
   end
+
+  scope "sponsors" do
+    get "/" => "sponsor#index"
+    post "/" => "sponsor#create"
+    get "/:sponsor_id" => "sponsor#show"
+    put "/:sponsor_id" => "sponsor#update"
+    delete "/:sponsor_id" => "sponsor#destroy"
+  end
 end

--- a/db/migrate/20180924191525_create_sponsors.rb
+++ b/db/migrate/20180924191525_create_sponsors.rb
@@ -4,8 +4,6 @@ class CreateSponsors < ActiveRecord::Migration[5.2]
       t.text :name
       t.text :description
       t.text :contacts
-      t.integer :duration
-      t.float :budget_amount
 
       t.timestamps
     end

--- a/db/migrate/20180924191551_create_leagues_sponsors.rb
+++ b/db/migrate/20180924191551_create_leagues_sponsors.rb
@@ -3,6 +3,9 @@ class CreateLeaguesSponsors < ActiveRecord::Migration[5.2]
     create_table :leagues_sponsors do |t|
       t.integer :league_id
       t.integer :sponsor_id
+      t.integer :duration
+      t.float :budget_amount
+
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,6 +60,8 @@ ActiveRecord::Schema.define(version: 2018_09_27_170652) do
   create_table "leagues_sponsors", force: :cascade do |t|
     t.integer "league_id"
     t.integer "sponsor_id"
+    t.integer "duration"
+    t.float "budget_amount"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -106,8 +108,6 @@ ActiveRecord::Schema.define(version: 2018_09_27_170652) do
     t.text "name"
     t.text "description"
     t.text "contacts"
-    t.integer "duration"
-    t.float "budget_amount"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,3 +46,11 @@ roles = [:Admin, :Referee, :Official, :Coach, :Sponsor, :Player, :User]
       description: Faker::Lorem.paragraph
   )
 end
+
+10.times do
+  Sponsor.create(
+    name: Faker::Bank.name,
+    description: Faker::Lorem.paragraph,
+    contacts: Faker::Internet.url
+  )
+  end

--- a/spec/factories/sponsors.rb
+++ b/spec/factories/sponsors.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :sponsor, class: Sponsor do
+    name { Faker::Bank.name }
+    description { Faker::Lorem.paragraph }
+    contacts { Faker::Internet.url }
+  end
+end

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -1,5 +1,12 @@
 require "rails_helper"
+require "./spec/support/request_helper"
 
 RSpec.describe Sponsor, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "Validations" do
+    context "when inputs must be present" do
+      it { should validate_presence_of(:name) }
+      it { should validate_presence_of(:description) }
+      it { should validate_presence_of(:contacts) }
+    end
+  end
 end

--- a/spec/requests/sponsor_spec.rb
+++ b/spec/requests/sponsor_spec.rb
@@ -1,0 +1,169 @@
+require "rails_helper"
+require "./spec/support/request_helper"
+
+RSpec.describe Sponsor, type: :request do
+  include RequestSpecHelper
+  include AuthenticationSpecHelper
+
+  let!(:role) { create(:role, name: "Admin") }
+
+  let!(:user) { create(:user, role_id: role.id) }
+
+  let!(:sponsor) { create_list(:sponsor, 10) }
+
+  let(:sponsor_id) { sponsor.first.id }
+
+  let(:sponsor_params) { attributes_for(:sponsor) }
+
+  describe "POST /sponsors" do
+    context "when the request is valid" do
+      before do
+        post "/sponsors",
+             headers: authenticated_header(user),
+             params: sponsor_params
+      end
+
+      it "creates a new sponsor with 6 attributes" do
+        expect(json.size).to eq 6
+      end
+
+      it "returns status code 201" do
+        expect(response).to have_http_status(201)
+      end
+    end
+
+    context "when the request is invalid" do
+      let(:sponsor_params) do
+        {
+          name: "",
+          description: "More money, less stress",
+          contacts: "https//www.example.com",
+        }
+      end
+
+      before do
+        post "/sponsors",
+             headers: authenticated_header(user),
+             params: sponsor_params
+      end
+
+      it "does not create a new sponsor with empty name" do
+        expect(json["name"]).to eq(["can't be blank"])
+      end
+
+      it "returns status code 422" do
+        expect(response).to have_http_status(422)
+      end
+    end
+  end
+
+  describe "GET /sponsors" do
+    context "when the request is valid" do
+      before { get "/sponsors" }
+
+      it "shows an array of 10 sponsors" do
+        expect(json.size).to eq 10
+      end
+
+      it "returns status code 200" do
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+
+  describe "GET /sponsors/:sponsor_id" do
+    context "when the request is valid" do
+      before { get "/sponsors/#{sponsor_id}" }
+
+      it "returns one sponsor's details" do
+        expect(json.size).to eq 6
+      end
+
+      it "returns status code 200" do
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when the request is invalid" do
+      let!(:sponsor_id) { 1000 }
+      before { get "/sponsors/#{sponsor_id}" }
+
+      it "returns an error message" do
+        expect(json["errors"]).to eq("The sponsor does not exist")
+      end
+
+      it "returns status code 400" do
+        expect(response).to have_http_status(400)
+      end
+    end
+  end
+
+  describe "DELETE /sponsors/:sponsor_id" do
+    context "when the request is valid" do
+
+      before do
+        delete "/sponsors/#{sponsor_id}",
+               headers: authenticated_header(user)
+      end
+
+      it "returns a success message" do
+        expect(json["message"]).to eq("Sponsor was successfully deleted")
+      end
+
+      it "returns status code 200" do
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when the request is invalid" do
+      let(:sponsor_id) { 100 }
+
+      before do
+        delete "/sponsors/#{sponsor_id}",
+               headers: authenticated_header(user)
+      end
+
+      it "returns an error message and status code 400" do
+        expect(json["errors"]).to eq("The sponsor does not exist")
+      end
+
+      it "returns status code 400" do
+        expect(response).to have_http_status(400)
+      end
+    end
+  end
+
+  describe "PUT /sponsors/:sponsor_id" do
+    context "when the request is valid" do
+      before do
+        put "/sponsors/#{sponsor_id}",
+            headers: authenticated_header(user)
+      end
+
+      it "returns a hash with 6 keys" do
+        expect(json.size).to eq 6
+      end
+
+      it "returns status code 200" do
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when the request is invalid" do
+      let(:sponsor_id) { 100 }
+
+      before do
+        put "/sponsors/#{sponsor_id}",
+            headers: authenticated_header(user)
+      end
+
+      it "returns an error message" do
+        expect(json["errors"]).to eq("The sponsor does not exist")
+      end
+
+      it "returns status code 400" do
+        expect(response).to have_http_status(400)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What does this PR do?
- Enables the Admin/user to perform CRUD operations to sponsors.

#### Description of Task to be completed?
- Test the sponsor requests and models.
- Update the schema for the league_sponsor and sponsors model changes.
- Test the model.
- Implement CRUD operations on the sponsor.

#### PT story?
- [#160750695](https://www.pivotaltracker.com/story/show/160750695)